### PR TITLE
Fix missing new directory during setup

### DIFF
--- a/data/placeholder.txt
+++ b/data/placeholder.txt
@@ -1,1 +1,0 @@
-nothing to see here

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -26,7 +26,9 @@ public class Storage {
     public Storage(String fileLocation) throws DukeException {
         try {
             dukeFile = new File(fileLocation);
-            dukeFile.createNewFile();
+            if (dukeFile.getParentFile().mkdir()) {
+                dukeFile.createNewFile();
+            }
         } catch (IOException e) {
             throw new StorageException(e.getMessage());
         }


### PR DESCRIPTION
When running on a new machine, the storage text file cannot be created at "data/duke.txt" due to a potentially missing "data" directory.

This PR resolves the above issue.